### PR TITLE
Use `obdb_id` as the primary ID

### DIFF
--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -138,7 +138,7 @@ class BreweriesController < ApplicationController
   end
 
   def set_brewery
-    @brewery = Brewery.find(params[:id])
+    @brewery = Brewery.find_by!(obdb_id: params[:id])
   end
 
   def track_analytics

--- a/app/serializers/brewery_serializer.rb
+++ b/app/serializers/brewery_serializer.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class BrewerySerializer < ActiveModel::Serializer
-  attribute :id
-  attribute :obdb_id
+  attribute :obdb_id, key: :id
   attribute :name
   attribute :brewery_type
   attribute :street

--- a/spec/factories/breweries.rb
+++ b/spec/factories/breweries.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :brewery do
-    obdb_id { "#{name.underscore}-#{city.underscore}" }
+    obdb_id { "#{name.parameterize}-#{city.parameterize}" }
     name { "#{Faker::Company.name} Brewery" }
     street { Faker::Address.street_address }
     address_2 { Faker::Address.secondary_address }

--- a/spec/requests/breweries_spec.rb
+++ b/spec/requests/breweries_spec.rb
@@ -157,14 +157,14 @@ RSpec.describe "Breweries API", type: :request do
         create_list(:brewery, 2, brewery_type: "nano")
         create_list(:brewery, 3, brewery_type: "planned")
       end
-      
+
       it "returns a filtered list of breweries - single" do
-        get "/breweries", params: {exclude_types: "micro"}
+        get "/breweries", params: { exclude_types: "micro" }
         expect(json.size).to eq(5)
       end
 
       it "returns a filtered list of breweries - multiple" do
-        get "/breweries", params: {exclude_types: "micro,nano"}
+        get "/breweries", params: { exclude_types: "micro,nano" }
         expect(json.size).to eq(3)
       end
     end
@@ -227,14 +227,14 @@ RSpec.describe "Breweries API", type: :request do
 
   describe "GET /breweries/:id" do
     let!(:brewery) { create(:brewery) }
-    let(:brewery_id) { brewery.id }
+    let(:brewery_id) { brewery.obdb_id }
 
     before { get "/breweries/#{brewery_id}" }
 
     context "when the record exists" do
       it "returns the brewery" do
         expect(json).not_to be_empty
-        expect(json["id"]).to eq(brewery.id)
+        expect(json["id"]).to eq(brewery.obdb_id)
         expect(json["name"]).to eq(brewery.name)
         expect(json["brewery_type"]).to eq(brewery.brewery_type)
         expect(json["street"]).to eq(brewery.street)
@@ -249,15 +249,15 @@ RSpec.describe "Breweries API", type: :request do
       end
 
       it "returns status code 200" do
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
     end
 
     context "when the record does not exist" do
-      let(:brewery_id) { 100 }
+      let(:brewery_id) { "fictional-brewery-nowhere" }
 
       it "returns status code 404" do
-        expect(response).to have_http_status(404)
+        expect(response).to have_http_status(:not_found)
       end
 
       it "returns a not found message" do


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE, but I don't think will affect things too badly unless apps are specifically looking for a numerical ID.**

## Motivation

- Since the `id` is currently linked to the auto-increment, it has the ability to change, which ruins consistency.
- The `obdb_id` is a lowercased and hyphenated combination of the brewery name and city, which creates a near-unique ID
  - NOTE: This is based on the Yelp URL scheme and probably a few others
  - Duplicates are currently handled by sequential numbers, starting with 1. Ex. `10-barrel-brewing-bend-1` and `10-barrel-brewing-bend-2`
  - `obdb_db` IDs are currently governed via the [dataset](https://github.com/openbrewerydb/openbrewerydb), but that may change.

Fixes #67 

