### PR TITLE
Fix: Remove unnecessary autocomplete args

### DIFF
--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -54,10 +54,6 @@ class BreweriesController < ApplicationController
       else
         Brewery.search(
           format_query(params[:query]),
-          fields: %w[name city state],
-          match: :word_start,
-          limit: 15,
-          load: false,
           misspellings: { below: 2 }
         ).map { |b| { id: b.obdb_id, name: b.name } }
       end


### PR DESCRIPTION
## Overview

Autocomplete wasn't returning any results. Searchkick has changed and these arguments don't really make sense anyway. Might as well just let ElasticSearch do its thing rather than unnecessarily constrain.
