### PR TITLE
Param validation updates

### DIFF
--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -152,7 +152,7 @@ class BreweriesController < ApplicationController
 
       case key
       when 'query'
-        error.push('Search cannot be blank.') if value.empty?
+        errors.push('Search cannot be blank.') if value.empty?
       when 'by_type'
         unless BREWERY_TYPES.include?(value)
           errors.push("Brewery type must include one of these types: #{BREWERY_TYPES}")

--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -151,8 +151,6 @@ class BreweriesController < ApplicationController
       value.gsub!('_', ' ') unless value.empty?
 
       case key
-      when 'query'
-        errors.push('Search cannot be blank.') if value.empty?
       when 'by_type'
         unless BREWERY_TYPES.include?(value)
           errors.push("Brewery type must include one of these types: #{BREWERY_TYPES}")

--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -7,7 +7,7 @@ class BreweriesController < ApplicationController
 
   before_action :set_brewery, only: %i[show update destroy]
   before_action :track_analytics
-  before_action :validate_params, only: %i[index]
+  before_action :validate_params, only: %i[index autocomplete search]
 
   # FILTER: /breweries?by_country=scotland
   has_scope :by_country, only: :index
@@ -54,7 +54,7 @@ class BreweriesController < ApplicationController
         { message: 'This endpoint is temporarily disabled.' }
       else
         Brewery.search(
-          format_query(params[:query]),
+          params[:query],
           misspellings: { below: 2 }
         ).map { |b| { id: b.obdb_id, name: b.name } }
       end
@@ -70,7 +70,7 @@ class BreweriesController < ApplicationController
         { message: 'This endpoint is temporarily disabled.' }
       else
         Brewery.search(
-          format_query(params[:query]),
+          params[:query],
           page: params[:page],
           per_page: params[:per_page]
         )
@@ -142,34 +142,28 @@ class BreweriesController < ApplicationController
     ahoy.track action_name, params
   end
 
-  # Allow _ to be a separator
-  def format_query(query)
-    query.gsub('_', ' ')
-  end
-
   def validate_params
+    errors = []
     params.each do |key, value|
       next if %w[controller action].include?(key)
 
-      # NOTE: Throwing error --
-      # `undefined method `last' for #<ActionController::Parameters {} permitted: false>`
-      # https://sentry.io/share/issue/3ff46bbbcf0d4affa0de1f5cdd0fc461/
-      #
-      # if DISALLOWED_CHARACTERS.include?(value.last)
-      #   render body: "#{key} query parameter has improper value.", status: :bad_request
-      #   return
-      # end
+      # Convert underscores to spaces in params (for convenience)
+      value.gsub!('_', ' ') unless value.empty?
 
       case key
+      when 'query'
+        error.push('Search cannot be blank.') if value.empty?
       when 'by_type'
         unless BREWERY_TYPES.include?(value)
-          render body: "Brewery type must include one of these types: #{BREWERY_TYPES}", status: :bad_request
+          errors.push("Brewery type must include one of these types: #{BREWERY_TYPES}")
         end
       when 'by_dist'
         unless value.split(',').map(&:to_f).size == 2
-          render body: "You must provide latitude and longitude for the 'by_dist' query param", status: :bad_request
+          errors.push("You must provide latitude and longitude for the 'by_dist' query param")
         end
       end
     end
+
+    return json_response({ errors: errors }, :bad_request) if errors.size.positive?
   end
 end

--- a/app/models/brewery.rb
+++ b/app/models/brewery.rb
@@ -7,8 +7,7 @@ class Brewery < ApplicationRecord
 
   geocoded_by :address
 
-  acts_as_mappable lat_column_name: :latitude,
-                   lng_column_name: :longitude
+  acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 
   validates :name, presence: true
   validates :city, presence: true
@@ -16,12 +15,12 @@ class Brewery < ApplicationRecord
   validates :country, presence: true
   validates :obdb_id, presence: true, uniqueness: true
 
-  scope :by_city, ->(city) { where('lower(city) LIKE ?', "%#{city.downcase}%") }
+  scope :by_city, ->(city) { where('lower(city) LIKE ?', "%#{sanitize_sql_like(city.downcase)}%") }
   scope :by_country, ->(country) { where('lower(country) = ?', country.downcase) }
-  scope :by_name, ->(name) { where('lower(name) LIKE ?', "%#{name.downcase}%") }
-  scope :by_state, ->(state) { where('lower(state) LIKE ?', state.downcase) }
+  scope :by_name, ->(name) { where('lower(name) LIKE ?', "%#{sanitize_sql_like(name.downcase)}%") }
+  scope :by_state, ->(state) { where('lower(state) LIKE ?', "%#{sanitize_sql_like(state.downcase)}%") }
   scope :by_type, ->(type) { where('lower(brewery_type) = ?', type.downcase) }
-  scope :by_postal, ->(postal) { where('postal_code LIKE ?', "#{postal}%") }
+  scope :by_postal, ->(postal) { where('postal_code LIKE ?', "%#{sanitize_sql_like(postal)}%") }
   scope :by_ids, ->(ids) { where(id: ids.split(',')) }
   scope :by_dist, ->(coords) { by_distance(origin: coords.split(',').map(&:to_f).first(2)) }
   scope :exclude_types, ->(types) { where('lower(brewery_type) NOT IN (?)', types.split(',')) }

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -11,5 +11,3 @@ BREWERY_TYPES = [
   "proprieter",
   "closed"
 ].freeze
-
-DISALLOWED_CHARACTERS = %w[\\ %].freeze

--- a/spec/requests/breweries_spec.rb
+++ b/spec/requests/breweries_spec.rb
@@ -139,12 +139,10 @@ RSpec.describe "Breweries API", type: :request do
         expect(json.size).to eq(0)
       end
 
-      # Passes, but throwing error on production
-      # https://sentry.io/share/issue/3ff46bbbcf0d4affa0de1f5cdd0fc461/
-      # it "throws an error when parameters have an ending escape" do
-      #   get "/breweries", params: { by_state: "delwar\\" }
-      #   expect(response).to have_http_status(400)
-      # end
+      it "sanitizes for SQL LIKE" do
+        get "/breweries", params: { by_state: "Cali\\" }
+        expect(response).to have_http_status(200)
+      end
     end
 
     context "when by_type param is passed" do


### PR DESCRIPTION
## Overview

A few tiny updates to @Johnnyk737's param validation solution (#82)

- Combine parameter validation (including search endpoints)
- Show multiple errors
- Return JSON
- Sanitize params for SQL LIKE (this took a little research to learn that Rails already had a function for this)

## Staging Tests

- [Search Test - /breweries/search?query=dog](http://staging-api.openbrewerydb.org/breweries/search?query=dog)
- [Empty Search Query Test - /breweries/search?query=](http://staging-api.openbrewerydb.org/breweries/search?query=)
- [Autocomplete Test - /breweries/autocomplete?query=dog](http://staging-api.openbrewerydb.org/breweries/autocomplete?query=dog)
- [Multiple Errors Test - /breweries?by_dist=73&by_type=none](http://staging-api.openbrewerydb.org/breweries?by_dist=73&by_type=none)
- [Search Test - /breweries/search?query=dog](http://staging-api.openbrewerydb.org/breweries/search?query=dog)
- [Invalid Query - /breweries?by_state=cali\\](http://staging-api.openbrewerydb.org/breweries?by_state=cali\\)
