### PR TITLE
fix: Random > Don't allow more than max allowed breweries

### DIFF
--- a/app/controllers/breweries_controller.rb
+++ b/app/controllers/breweries_controller.rb
@@ -48,10 +48,10 @@ class BreweriesController < ApplicationController
   # GET /breweries/random
   def random
     expires_in 1.day, public: true
-    size = params[:size] || 1
+    size = params[:size].to_i == 0 ? 1 : params[:size].to_i
 
     # ActiveRecord random record: https://stackoverflow.com/a/25577054
-    @breweries = Brewery.order(Arel.sql('RANDOM()')).limit(size)
+    @breweries = Brewery.order(Arel.sql('RANDOM()')).limit([size, MAX_PER_PAGE].min)
 
     json_response(@breweries)
   end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -11,3 +11,5 @@ BREWERY_TYPES = [
   "proprieter",
   "closed"
 ].freeze
+
+MAX_PER_PAGE = 50

--- a/spec/requests/breweries_spec.rb
+++ b/spec/requests/breweries_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe "Breweries API", type: :request do
 
   describe "GET /breweries/random" do
     before do
-      create_list(:brewery, 5)
+      create_list(:brewery, 55)
     end
 
     it "returns a brewery" do
@@ -256,6 +256,11 @@ RSpec.describe "Breweries API", type: :request do
     it "returns a number of breweries when size param" do
       get "/breweries/random", params: { size: 3 }
       expect(json.size).to eq(3)
+    end
+
+    it "does not return more breweries than the max allowed" do
+      get "/breweries/random", params: { size: 51 }
+      expect(json.size).to eq(50)
     end
   end
 


### PR DESCRIPTION
## Overview

Fix bug where there was no limit on the `size` parameter. The exploit made it possible to return the entire dataset, which took ~2s to query and respond.